### PR TITLE
Update Endor Labs Package Risk Summary agent

### DIFF
--- a/claude-code/package-risk-summary/enterprise-edition/endorctl-setup.md
+++ b/claude-code/package-risk-summary/enterprise-edition/endorctl-setup.md
@@ -1,6 +1,6 @@
 # endorctl Setup
 
-The Enterprise Edition Dependency Decision Helper uses read-only Endor lookups
+The Enterprise Edition Endor Labs Package Risk Summary uses read-only Endor lookups
 through `endorctl api` for package scores, license classification, and
 similar-package signals. Install and authenticate `endorctl` before
 using the Enterprise Edition artifact.

--- a/manifest.json
+++ b/manifest.json
@@ -78,9 +78,9 @@
               "sha256": "43db385a1cb1ea41b39f6ec54ffd5166dc8072ea33e316c392d0a784597b7c18"
             },
             {
-              "bytes": 828,
+              "bytes": 833,
               "path": "claude-code/package-risk-summary/enterprise-edition/endorctl-setup.md",
-              "sha256": "37f33aff3efd6bb6171cf194caad2f14d1b7b4b00b886497a0c71df094465c39"
+              "sha256": "3944dc4656bc9a231d30580e7d25c4a2d2afa7393ce5960128fb3f7c56910a99"
             },
             {
               "bytes": 9490,


### PR DESCRIPTION
## Summary

This promotion updates customer-facing artifacts for **Endor Labs Package Risk Summary**.

## Agent Updates

### Updated Agent: Endor Labs Package Risk Summary

Summarizes the risk posture of a specific package version without turning the result into a yes/no adoption decision.

- Agent id: `package-risk-summary`
- Developer Edition: MCP-only, no Bash access.
- Enterprise Edition: MCP plus documented read-only `endorctl api` lookups.
- Example: `@agent-package-risk-summary summarize npm lodash version 4.17.20`

## Published Artifacts

- `claude-code/package-risk-summary/enterprise-edition/endorctl-setup.md`
- `manifest.json`

## Safety

All published agents in this kit are read-only. They report unavailable
signals as `data_gaps` instead of inventing evidence, and any shell access
is limited by the agent instructions to documented read-only Endor lookups.
