### PR TITLE
Automate Endor context refresh and demote upstream drift to a warning

### DIFF
--- a/.github/workflows/agent-kit-ci.yml
+++ b/.github/workflows/agent-kit-ci.yml
@@ -91,4 +91,21 @@ jobs:
       - name: Verify Endor context freshness
         run: |
           . .venv/bin/activate
-          endor-agent-kit verify-endor-context --upstream
+          endor-agent-kit verify-endor-context
+          if endor-agent-kit verify-endor-context --upstream; then
+            echo "Endor context pin matches upstream."
+          else
+            echo "::warning title=Endor context drift (non-blocking)::Upstream Endor OpenAPI/docs moved since source/endor-context/provenance.json was pinned. This is external drift, not caused by this commit. Merge the automated 'Refresh Endor context provenance' PR, or run 'endor-agent-kit refresh-endor-context', review per docs/maintainer-guide.md, and commit the refreshed pin."
+            {
+              echo "## Endor context drift detected (non-blocking)"
+              echo ""
+              echo "Upstream Endor OpenAPI/docs moved since \`source/endor-context/provenance.json\` was pinned."
+              echo "This is external drift, not a failure introduced by this commit."
+              echo ""
+              echo "To refresh the pin:"
+              echo ""
+              echo "1. Merge the automated **Refresh Endor context provenance** PR if one is open (created daily by \`.github/workflows/refresh-endor-context.yml\`), or run \`endor-agent-kit refresh-endor-context\` locally."
+              echo "2. Review affected Source Recipes, Knowledge Pack query recipes, and setup guidance per \`docs/maintainer-guide.md\` (\"Refresh Endor API And Docs Context\")."
+              echo "3. Commit the updated \`source/endor-context/provenance.json\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/refresh-endor-context.yml
+++ b/.github/workflows/refresh-endor-context.yml
@@ -1,0 +1,89 @@
+name: Refresh Endor context
+
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.10"
+
+      - name: Install Agent Kit
+        run: |
+          python -m venv .venv
+          . .venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Refresh Endor context provenance
+        run: |
+          . .venv/bin/activate
+          endor-agent-kit refresh-endor-context
+
+      - name: Validate refreshed provenance
+        run: |
+          . .venv/bin/activate
+          endor-agent-kit verify-endor-context --upstream
+          python -m pytest -q tests/test_endor_context.py
+
+      - name: Open or update refresh PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if git diff --quiet source/endor-context/provenance.json; then
+            echo "Endor context provenance already matches upstream."
+            exit 0
+          fi
+
+          branch="endor-context-refresh"
+          git config user.name "endor-agent-kit-sync[bot]"
+          git config user.email "endor-agent-kit-sync[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
+          git add source/endor-context/provenance.json
+          git commit -m "Refresh Endor context provenance from upstream"
+          git push --force origin "$branch"
+
+          cat > /tmp/refresh-pr-body.md <<'BODY'
+          Automated refresh of `source/endor-context/provenance.json` from upstream
+          Endor Labs endpoints. The refreshed pin was verified against upstream and
+          passed `tests/test_endor_context.py` in this workflow run.
+
+          Before merging, review per `docs/maintainer-guide.md`
+          ("Refresh Endor API And Docs Context"):
+
+          - [ ] Source Recipes still read correctly against the new API surface
+          - [ ] Knowledge Pack query recipes (`source/endor-knowledge-pack/`) are unaffected
+          - [ ] Setup guidance (`source/plugin-support/setup/setup.md`) is unaffected
+          - [ ] Release docs do not reference removed endpoints or flags
+
+          If any of these need changes, make them in Agent Kit source first and
+          regenerate before merging this refresh.
+          BODY
+
+          title="Refresh Endor context provenance"
+          if gh pr view "$branch" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh pr edit "$branch" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$title" \
+              --body-file /tmp/refresh-pr-body.md
+          else
+            gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --base main \
+              --head "$branch" \
+              --title "$title" \
+              --body-file /tmp/refresh-pr-body.md
+          fi

--- a/docs/maintainer-guide.md
+++ b/docs/maintainer-guide.md
@@ -89,14 +89,29 @@ Agent Kit does not crawl Endor docs or fetch OpenAPI during normal agent
 runtime. Maintainers instead commit a small provenance file under
 `source/endor-context/` and let CI compare it with upstream.
 
-`endor-agent-kit verify-endor-context --upstream` treats OpenAPI SHA drift and
-canonical docs URL drift as blocking. The public `/meta/version` signal is
+`endor-agent-kit verify-endor-context --upstream` reports OpenAPI SHA drift and
+canonical docs URL drift as errors. The public `/meta/version` signal is
 warning-only because an Endor service/client release may not require prompt or
 query recipe changes.
 
-When the upstream drift is intentional, inspect affected Source Recipes,
-Knowledge Pack query recipes, setup guidance, and release docs first. If they
-still read correctly, refresh the provenance:
+In CI (`agent-kit-ci.yml`), the offline payload validation
+(`endor-agent-kit verify-endor-context` without `--upstream`) stays blocking,
+but upstream drift is reported as a non-blocking warning with refresh
+instructions in the job summary. Upstream drift is caused by Endor releases,
+not by the commit under test, so it must not fail unrelated PRs or pushes.
+
+Freshness is automated by `.github/workflows/refresh-endor-context.yml`, which
+runs daily (and on manual dispatch), re-pins the provenance from upstream,
+verifies it, and opens or updates a **Refresh Endor context provenance** PR on
+branch `endor-context-refresh` when anything moved. Creating that PR with the
+default `GITHUB_TOKEN` requires the repository setting "Allow GitHub Actions to
+create and approve pull requests"; note that PRs opened by `GITHUB_TOKEN` do
+not trigger CI runs themselves — the refresh workflow validates the new pin
+before opening the PR.
+
+Before merging a refresh (automated or manual), inspect affected Source
+Recipes, Knowledge Pack query recipes, setup guidance, and release docs first.
+If they still read correctly, merge the automated PR or refresh locally:
 
 ```bash
 endor-agent-kit refresh-endor-context

--- a/source/endor-context/provenance.json
+++ b/source/endor-context/provenance.json
@@ -1,17 +1,17 @@
 {
   "schema_version": 1,
-  "checked_at": "2026-06-07",
+  "checked_at": "2026-06-10",
   "openapi": {
     "url": "https://api.endorlabs.com/download/openapiv2.swagger.json",
-    "sha256": "2fc220f7f4957e673c86129b47c5c5e407c2c9d30a1f84cae680ca2943ad1a88",
-    "bytes": 4244676,
+    "sha256": "42cf9fe067cf6934fb435d012e32485200d982e9d9cff163c699cd0571981d1c",
+    "bytes": 4248611,
     "failure_mode": "blocking"
   },
   "meta_version": {
     "url": "https://api.endorlabs.com/meta/version",
-    "client_version": "v1.7.994",
-    "service_version": "v1.7.994",
-    "service_sha": "129e5749ae0d301acddaf487e12cb513d5a2e593",
+    "client_version": "v1.7.998",
+    "service_version": "v1.7.998",
+    "service_sha": "c3625070ef8b06d5b9b217162d9a09b6da6eb45f",
     "failure_mode": "warning"
   },
   "docs": [

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -25,4 +25,22 @@ def test_ci_workflow_runs_guardrail_conformance_check():
 def test_ci_workflow_runs_endor_context_freshness_check():
     workflow = (repo_root() / ".github" / "workflows" / "agent-kit-ci.yml").read_text()
 
+    # Offline payload validation stays blocking; the upstream freshness check
+    # stays wired in but reports drift as a non-blocking warning because
+    # upstream Endor releases are not failures of the commit under test.
+    assert "endor-agent-kit verify-endor-context\n" in workflow
     assert "endor-agent-kit verify-endor-context --upstream" in workflow
+    assert "Endor context drift" in workflow
+
+
+def test_refresh_endor_context_workflow_automates_freshness():
+    workflow = (
+        repo_root() / ".github" / "workflows" / "refresh-endor-context.yml"
+    ).read_text()
+
+    # The scheduled refresh lane must keep re-pinning provenance from upstream
+    # and verifying it before opening the review PR.
+    assert "schedule" in workflow
+    assert "endor-agent-kit refresh-endor-context" in workflow
+    assert "endor-agent-kit verify-endor-context --upstream" in workflow
+    assert "endor-context-refresh" in workflow


### PR DESCRIPTION
## Problem

The `Verify Endor context freshness` step in Agent Kit CI failed on the merge of #30 ([run](https://github.com/endorlabs/endor-labs-agent-kit/actions/runs/27272773601/job/80546184838)) because Endor shipped v1.7.998 upstream, changing the published OpenAPI spec sha256 versus the pin committed in `source/endor-context/provenance.json` (last refreshed 2026-06-07 at v1.7.994). That drift is external — it is not a failure of the commit under test, and it will keep failing every push/PR until someone refreshes the pin.

## Changes

1. **CI gate split** (`agent-kit-ci.yml`): the offline payload validation (`endor-agent-kit verify-endor-context`) stays blocking; the network freshness check (`--upstream`) still runs but reports drift as a `::warning::` annotation plus step-summary instructions (what happened, why it is not the commit's fault, exactly how to fix it) instead of failing the job.
2. **Automated refresh lane** (new `refresh-endor-context.yml`): daily schedule + manual dispatch. Re-pins provenance from upstream, verifies it (`verify-endor-context --upstream` + `tests/test_endor_context.py`), and opens/updates a **Refresh Endor context provenance** PR on branch `endor-context-refresh` with the maintainer-guide review checklist in the body.
3. **Pin refreshed now**: `source/endor-context/provenance.json` re-pinned to upstream (OpenAPI `42cf9fe0…`, v1.7.998, checked 2026-06-10) and verified green, so the freshness signal is clean at merge.
4. **Docs + meta-tests**: maintainer-guide section updated for the new behavior; `tests/test_ci_workflow.py` now pins both the blocking offline check and the automated refresh workflow so neither can silently disappear.

## Notes

- Creating the refresh PR with the default `GITHUB_TOKEN` requires the repo setting **Allow GitHub Actions to create and approve pull requests** (Settings → Actions → General). PRs opened by `GITHUB_TOKEN` do not trigger CI themselves; the refresh workflow validates the new pin before opening the PR, and the maintainer review checklist covers the rest.
- Validation: `pytest -q` 306 passed; both workflow files parse; `verify-endor-context --upstream` green against the refreshed pin; `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)