### PR TITLE
Add Amp MCP setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A machine-readable index is available in `llms.txt`.
 | 🐍 Cursor SDK | Python SDK launcher and generated prompts for automation | [`cursor-sdk/README.md`](cursor-sdk/README.md) |
 | 🧩 Single-agent bundles | Manual per-host artifacts and README files | [Agent Catalog](#agent-catalog) |
 | 🧱 Portable bundles | Runtime-neutral prompts, manifests, output contracts, and adapter expectations | [`portable/`](portable/) |
+| ⚡ Amp MCP setup | MCP-only setup for exposing Endor Labs tools to Amp | [`docs/amp-mcp.md`](docs/amp-mcp.md) |
 | 🛠️ Source recipes | Maintainer-only source of truth for behavior, evals, actions, and diagrams | [`source/agents/`](source/agents/) |
 | 🔒 Guardrails | Safety, provenance, runtime, and documentation validation | [`docs/guardrails.md`](docs/guardrails.md) |
 
@@ -217,6 +218,7 @@ are the generated host directories listed in the catalog.
 | Antigravity | `plugins/antigravity/endor-labs-agent-kit/` | Antigravity CLI plugin install with generated skills and subagents |
 | Cursor | `.cursor-plugin/`, `agents/<agent>.md`, `skills/<agent>/`, and `assets/logo.png` | Cursor plugin install with generated agents and support skills; Gemini extension files are separate |
 | Cursor SDK | `cursor-sdk/` | Python automation, CI, orchestration, backend services, local SDK agents, or Cursor cloud agents |
+| Amp | `docs/amp-mcp.md` | MCP-only Endor Labs tool setup; no generated Agent Kit plugin package in this repository |
 | Portable | `portable/<agent>/` | Customer-managed agent runtime, workflow engine, or internal platform |
 
 ## 🧱 Already Have Your Own Tech Stack Or Workflows Wired?
@@ -295,6 +297,10 @@ on Endor package/vulnerability lookup tools that do not yet have an
 
 If MCP is unavailable, those agents must record the missing signal in
 `data_gaps` rather than blocking install or fabricating evidence.
+
+Amp can use the same Endor Labs MCP server through Amp's `amp.mcpServers`
+configuration. See [`docs/amp-mcp.md`](docs/amp-mcp.md) for Developer Edition,
+Enterprise Edition, workspace settings, and Windows direct-binary examples.
 
 Portable bundles do not configure MCP servers. They declare transport
 requirements in `agent.manifest.json`. If a portable agent requires MCP,

--- a/docs/amp-mcp.md
+++ b/docs/amp-mcp.md
@@ -1,0 +1,209 @@
+# Amp MCP Setup
+
+Use this guide to connect Endor Labs Agent Kit support context to
+[Amp](https://ampcode.com/) through the Endor Labs MCP server. Amp does not
+currently have a generated Agent Kit plugin package in this repository; this is
+an MCP-only setup path for exposing Endor Labs tools to Amp.
+
+## What This Enables
+
+After setup, Amp can call the Endor Labs MCP server to:
+
+- check a dependency version for known vulnerabilities
+- check a dependency for broader package risk, including malware signals
+- retrieve Endor vulnerability details
+- run local repository scans for dependencies, secrets, SAST, AI SAST, and
+  GitHub Actions risks, depending on account edition and scan options
+- run Endor security review for local diffs when Enterprise Edition and AI
+  security code review are enabled
+
+The MCP server runs locally over stdio. Amp launches it as a tool server and the
+server handles Endor authentication through `endorctl`.
+
+## Prerequisites
+
+- Amp CLI installed and signed in.
+- Node.js and `npx` available, or a directly installed `endorctl` binary.
+- For Enterprise Edition, an Endor Labs namespace and configured authentication
+  mode.
+
+## Developer Edition
+
+Developer Edition uses Endor Labs default policies. It does not require a paid
+Endor Labs namespace.
+
+Add the MCP server to Amp global settings:
+
+```bash
+amp mcp add endor-cli-tools -- npx -y endorctl ai-tools mcp-server
+```
+
+Equivalent Amp settings JSON:
+
+```json
+{
+  "amp.mcpServers": {
+    "endor-cli-tools": {
+      "command": "npx",
+      "args": ["-y", "endorctl", "ai-tools", "mcp-server"]
+    }
+  }
+}
+```
+
+Use `--workspace` when the configuration should be committed or reviewed as a
+workspace-specific `.amp/settings.json` file instead of a user-wide setting:
+
+```bash
+amp mcp add --workspace endor-cli-tools -- npx -y endorctl ai-tools mcp-server
+```
+
+Workspace MCP servers require Amp workspace trust approval before they run.
+
+## Enterprise Edition
+
+Enterprise Edition connects Amp to an Endor Labs namespace so checks use the
+organization's policies, permissions, and reporting context.
+
+Example with SSO:
+
+```bash
+amp mcp add endor-cli-tools \
+  --env ENDOR_NAMESPACE=your-namespace \
+  --env ENDOR_MCP_SERVER_AUTH_MODE=sso \
+  --env ENDOR_MCP_SERVER_AUTH_TENANT=your-tenant \
+  -- npx -y endorctl ai-tools mcp-server
+```
+
+Example with GitHub authentication:
+
+```bash
+amp mcp add endor-cli-tools \
+  --env ENDOR_NAMESPACE=your-namespace \
+  --env ENDOR_MCP_SERVER_AUTH_MODE=github \
+  -- npx -y endorctl ai-tools mcp-server
+```
+
+Equivalent Amp settings JSON:
+
+```json
+{
+  "amp.mcpServers": {
+    "endor-cli-tools": {
+      "command": "npx",
+      "args": ["-y", "endorctl", "ai-tools", "mcp-server"],
+      "env": {
+        "ENDOR_NAMESPACE": "your-namespace",
+        "ENDOR_MCP_SERVER_AUTH_MODE": "sso",
+        "ENDOR_MCP_SERVER_AUTH_TENANT": "your-tenant"
+      }
+    }
+  }
+}
+```
+
+For non-SSO Enterprise authentication, set `ENDOR_MCP_SERVER_AUTH_MODE` to the
+organization-approved mode such as `github`, `gitlab`, or `google`, and omit
+`ENDOR_MCP_SERVER_AUTH_TENANT` unless SSO requires it.
+
+## Windows Direct-Binary Fallback
+
+If `npx -y endorctl ...` downloads the package but Amp cannot start the MCP
+server, install or locate `endorctl` and configure Amp to call the executable
+directly.
+
+Common Windows npm binary path:
+
+```text
+%APPDATA%\npm\bin\endorctl.exe
+```
+
+PowerShell example:
+
+```powershell
+amp mcp add endor-cli-tools -- "$env:APPDATA\npm\bin\endorctl.exe" ai-tools mcp-server
+```
+
+Equivalent settings JSON:
+
+```json
+{
+  "amp.mcpServers": {
+    "endor-cli-tools": {
+      "command": "C:\\Users\\<user>\\AppData\\Roaming\\npm\\bin\\endorctl.exe",
+      "args": ["ai-tools", "mcp-server"]
+    }
+  }
+}
+```
+
+Use an absolute path in settings JSON because MCP command fields may not expand
+shell variables.
+
+## Verify The Integration
+
+List configured MCP servers:
+
+```bash
+amp mcp list
+```
+
+Check server status:
+
+```bash
+amp mcp doctor
+```
+
+Then ask Amp to run a dependency check:
+
+```text
+Check if the npm package lodash version 4.17.20 has any vulnerabilities using Endor Labs.
+```
+
+Amp should call the Endor Labs MCP tool and return vulnerability status,
+advisory identifiers, and a remediation recommendation when available.
+
+## Optional Project Guidance
+
+Add project-level guidance when you want Amp to use Endor Labs automatically for
+specific workflows. For example, add the following to `AGENTS.md` in a
+repository that uses Amp:
+
+```markdown
+# Endor Labs Security Workflow For Amp
+
+This repository uses Endor Labs through the Amp MCP server `endor-cli-tools`.
+
+When dependency manifests or lockfiles are created or modified:
+
+- Use the Endor Labs MCP tool `check_dependency_for_vulnerabilities` for each
+  added or changed dependency when the ecosystem, dependency name, and version
+  are known.
+- If a dependency is vulnerable, recommend or apply the smallest safe upgrade
+  that satisfies the repository constraints.
+- Re-check the dependency after remediation.
+
+For security-sensitive code changes, consider the Endor Labs MCP `scan` tool
+with the narrowest relevant scan types. Use `security_review` only when the
+Endor Labs account edition and namespace are configured for AI security code
+review.
+
+Do not print, persist, or copy secret values. Report credential presence only
+by variable or key name.
+```
+
+Keep the guidance scoped. Do not force a full scan after every edit unless the
+project explicitly wants that latency and policy behavior.
+
+## Troubleshooting
+
+- If Amp cannot see the tools, restart the Amp session after adding the MCP
+  server.
+- If a workspace MCP server is awaiting approval, run
+  `amp mcp approve endor-cli-tools` from the workspace.
+- If `npx` times out or fails behind a proxy, use the direct `endorctl` binary
+  fallback.
+- If Enterprise tools return authorization errors, verify the namespace,
+  authentication mode, SSO tenant when applicable, and user permissions.
+- If `security_review` is unavailable, confirm Enterprise Edition is enabled and
+  AI security code review is enabled for the namespace.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,6 +14,7 @@ use `docs/maintainer-guide.md` or `docs/distribution-sync.md` instead.
 | Antigravity CLI | `plugins/antigravity/endor-labs-agent-kit/README.md` | Antigravity plugin install with skills and subagents. |
 | Cursor | `.cursor-plugin/`, root `agents/`, and root `skills/` | Cursor plugin metadata with generated workflow agents and support skills. |
 | Cursor SDK | `cursor-sdk/README.md` | Python SDK automation for local workspaces, CI, orchestration, backend services, or Cursor cloud agents. |
+| Amp | `docs/amp-mcp.md` | MCP-only setup for exposing Endor Labs tools to Amp. |
 | Manual single-agent install | `<host>/<agent>/README.md` | One workflow in one host without the full plugin package. |
 | Runtime-neutral integration | `portable/<agent>/README.md` | Internal runtime with its own adapters, approvals, audit, and credentials. |
 
@@ -134,6 +135,7 @@ Use the findings-browser skill to show the critical and high reachable findings 
 
 - Agent and host catalog: `README.md`
 - Agent-facing operating rules: `docs/for-agents.md`
+- Amp MCP setup: `docs/amp-mcp.md`
 - Maintainer workflow: `docs/maintainer-guide.md`
 - Public mirror sync: `docs/distribution-sync.md`
 - Runtime-neutral adapter requirements: `docs/portable-runtime-conformance.md`

--- a/llms.txt
+++ b/llms.txt
@@ -13,6 +13,7 @@
 - `docs/distribution-sync.md`: source-to-`ai-plugins` mirror process.
 - `docs/plugin-release-checklist.md`: release validation matrix.
 - `docs/guardrails.md`: safety and runtime-control documentation.
+- `docs/amp-mcp.md`: MCP-only setup for exposing Endor Labs tools to Amp.
 - `docs/portable-runtime-conformance.md`: portable adapter and approval-gate contract.
 
 ## Source Of Truth


### PR DESCRIPTION
## Summary
- Add an Amp MCP setup guide for the Endor Labs MCP server.
- Document Developer Edition and Enterprise Edition Amp configuration examples.
- Include workspace settings, Windows direct-binary fallback, verification prompts, troubleshooting, and optional AGENTS.md guidance.
- Link the Amp guide from README, getting-started docs, and llms.txt.

## Scope
This is an MCP-only Amp integration guide. It does not add a generated Amp host package or change generated Agent Kit behavior.

## Validation
- Passed: \git diff --check\.
- Attempted: \PYTHONPATH=src python -m endor_agent_kit.cli check-guardrails --catalog-root .\; this Windows checkout reports manifest checksum mismatches across existing generated artifacts, likely due line-ending normalization, before/independent of this docs-only change.
- Attempted: \PYTHONPATH=src python -m pytest -q\; it did not complete within the local 120s timeout after entering the existing test suite. This PR changes docs only.