### PR TITLE
Fix catalog signing digest encoding for Azure Key Vault

### DIFF
--- a/scripts/sign_catalog_akv.sh
+++ b/scripts/sign_catalog_akv.sh
@@ -13,14 +13,20 @@ signature="${2:-catalog.json.sig}"
 : "${CATALOG_SIGNING_VAULT:?set CATALOG_SIGNING_VAULT (Azure Key Vault name)}"
 : "${CATALOG_SIGNING_KEY:?set CATALOG_SIGNING_KEY (Key Vault key name)}"
 
-# AKV signs a precomputed digest; ES256 takes the SHA-256 digest as base64url (unpadded).
-digest_b64url="$(openssl dgst -sha256 -binary "$catalog" | basenc --base64url | tr -d '=')"
+# AKV signs a precomputed digest. `az keyvault key sign` decodes --digest with
+# standard base64 (base64.b64decode), which drops base64url's -/_, so encode the
+# SHA-256 digest as standard padded base64 to keep all 32 bytes intact.
+digest_b64="$(openssl dgst -sha256 -binary "$catalog" | python -c '
+import sys
+from endor_agent_kit.catalog_signing import akv_digest_arg
+sys.stdout.write(akv_digest_arg(sys.stdin.buffer.read()))
+')"
 
 raw_b64url="$(az keyvault key sign \
   --vault-name "$CATALOG_SIGNING_VAULT" \
   --name "$CATALOG_SIGNING_KEY" \
   --algorithm ES256 \
-  --digest "$digest_b64url" \
+  --digest "$digest_b64" \
   --query 'result' -o tsv)"
 
 # AKV returns a raw P1363 (r||s) signature; convert to DER for the pinned-public-key

--- a/src/endor_agent_kit/catalog_signing.py
+++ b/src/endor_agent_kit/catalog_signing.py
@@ -14,11 +14,28 @@ shape ``openssl dgst -verify`` and Go's ``ecdsa.VerifyASN1`` both accept.
 
 from __future__ import annotations
 
+import base64
 from pathlib import Path
 import subprocess
 
 SIGNATURE_SUFFIX = ".sig"
 _ES256_RAW_LEN = 64  # P-256 r||s: two 32-byte integers
+_ES256_DIGEST_LEN = 32  # SHA-256 digest fed to ES256 sign
+
+
+def akv_digest_arg(digest: bytes) -> str:
+    """Encode a SHA-256 digest for ``az keyvault key sign --digest``.
+
+    The CLI decodes ``--digest`` with standard ``base64.b64decode``, which
+    silently discards base64url's ``-``/``_`` characters. A base64url digest that
+    happens to contain them therefore reaches Key Vault short of 32 bytes and is
+    rejected ("ES256 requires 32 bytes"); standard padded base64 survives that
+    decoder intact.
+    """
+
+    if len(digest) != _ES256_DIGEST_LEN:
+        raise ValueError(f"ES256 digest must be {_ES256_DIGEST_LEN} bytes (SHA-256); got {len(digest)}")
+    return base64.b64encode(digest).decode("ascii")
 
 
 def der_from_raw_p1363(raw: bytes) -> bytes:

--- a/tests/test_catalog_signing.py
+++ b/tests/test_catalog_signing.py
@@ -1,15 +1,51 @@
 from __future__ import annotations
 
+import base64
+import hashlib
 import subprocess
 
 import pytest
 
 from endor_agent_kit.catalog_signing import (
+    akv_digest_arg,
     der_from_raw_p1363,
     raw_p1363_from_der,
     sign_catalog,
     verify_catalog_signature,
 )
+
+
+def _digest_with_urlsafe_chars() -> bytes:
+    # SHA-256 of b"0" base64url-encodes to a string containing both '-' and '_' --
+    # exactly the data-dependent case that broke the first signed release.
+    digest = hashlib.sha256(b"0").digest()
+    b64url = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    assert "-" in b64url and "_" in b64url
+    return digest
+
+
+def test_akv_digest_arg_round_trips_through_cli_decoder():
+    # `az keyvault key sign` decodes --digest with standard base64; the argument
+    # must decode back to the exact 32 digest bytes even when the base64url form
+    # contains -/_.
+    digest = _digest_with_urlsafe_chars()
+    decoded = base64.b64decode(akv_digest_arg(digest))
+    assert decoded == digest
+    assert len(decoded) == 32
+
+
+def test_akv_digest_arg_regression_base64url_would_lose_bytes():
+    # The original bug: base64url-unpadded, decoded by the CLI's standard base64
+    # decoder, silently drops -/_ and reaches Key Vault short of 32 bytes.
+    digest = _digest_with_urlsafe_chars()
+    b64url = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    assert len(base64.b64decode(b64url)) < 32  # what AKV received before the fix
+    assert base64.b64decode(akv_digest_arg(digest)) == digest  # fixed path
+
+
+def test_akv_digest_arg_rejects_wrong_length():
+    with pytest.raises(ValueError, match="32 bytes"):
+        akv_digest_arg(b"\x00" * 31)
 
 
 def _has_openssl() -> bool:


### PR DESCRIPTION
## What

The catalog signing script encoded the SHA-256 digest as unpadded base64url before
passing it to `az keyvault key sign --digest`. That CLI decodes its argument with
standard base64, which silently drops base64url's `-` and `_` characters. When a
digest's base64url form contained those characters, fewer than 32 bytes reached
Key Vault and the sign call failed:

```
(BadParameter) Invalid length of 'value': 30 bytes. ES256 requires 32 bytes, encoded with base64url.
```

The bug is data-dependent: it only trips when the digest contains `-`/`_`, so it
surfaced on the first release whose catalog digest happened to include them.

## Fix

Encode the digest as standard padded base64 so it survives the CLI's decoder intact.
The encoding now lives in a small pure helper, `akv_digest_arg`, in
`endor_agent_kit.catalog_signing`, and the script calls it (mirroring the existing
Python call used for the DER conversion). ES256/P-256 and the DER output are
unchanged; only the digest argument encoding changes.

## Tests

Added unit tests in `tests/test_catalog_signing.py`:
- round-trip: the argument decodes (via the CLI's standard-base64 decoder) back to
  the exact 32 digest bytes, using a digest whose base64url form contains both
  `-` and `_`.
- regression: proves the old base64url encoding decodes to fewer than 32 bytes
  under that decoder, while the fixed path yields the full digest.
- length guard: rejects a non-32-byte digest.

## Validation note

The signing path only runs inside the release workflow (OIDC-federated Azure login,
`CATALOG_SIGNING_ENABLED=true`), so end-to-end verification against Key Vault
happens on the next tagged release. The failed run confirmed Azure login and the
key role both work; the failure was purely this client-side encoding.
