### PR TITLE
Fix Azure Key Vault sign query field for catalog signing

### DIFF
--- a/scripts/sign_catalog_akv.sh
+++ b/scripts/sign_catalog_akv.sh
@@ -22,12 +22,20 @@ from endor_agent_kit.catalog_signing import akv_digest_arg
 sys.stdout.write(akv_digest_arg(sys.stdin.buffer.read()))
 ')"
 
+# `az keyvault key sign` returns the signature under `signature` (encrypt/decrypt
+# use `result`, sign/verify do not).
 raw_b64url="$(az keyvault key sign \
   --vault-name "$CATALOG_SIGNING_VAULT" \
   --name "$CATALOG_SIGNING_KEY" \
   --algorithm ES256 \
   --digest "$digest_b64" \
-  --query 'result' -o tsv)"
+  --query 'signature' -o tsv)"
+
+# Fail loudly here rather than let an empty value surface as an opaque length error downstream.
+if [ -z "$raw_b64url" ]; then
+  echo "az keyvault key sign returned no signature (check --query field and key permissions)" >&2
+  exit 1
+fi
 
 # AKV returns a raw P1363 (r||s) signature; convert to DER for the pinned-public-key
 # verifiers (openssl dgst -verify, apiserver ecdsa.VerifyASN1).


### PR DESCRIPTION
## What

The catalog signing run got past the digest fix and Azure OIDC login, then failed at
DER conversion with:

```
ValueError: ES256 raw signature must be 64 bytes (r||s over P-256); got 0
```

The signing script read the signature from `az keyvault key sign --query 'result'`, but
that command returns the signature under the `signature` field. `result` is the field for
`az keyvault key encrypt`/`decrypt`, not `sign`/`verify`. The query matched nothing, so an
empty value flowed downstream and produced the opaque length error.

Output schema per Microsoft docs: `{ "algorithm", "keyId", "signature" }`.

## Fix

- Query the `signature` field.
- Add an explicit guard: if the signature comes back empty, fail immediately with a clear
  message instead of letting a 0-byte value surface as a cryptic DER length error later.

## Validation note

The signing path only runs in the release workflow (OIDC-federated Azure login), so the
end-to-end AKV round-trip is exercised on the next tagged release. This is the second
issue in this script that could only surface against the live vault; a follow-up to add a
sign-only, non-publishing test path (so the AKV path can be exercised without cutting a
release tag) is worth doing separately.
