### PR TITLE
Add a manual dry-run trigger for the catalog signing round-trip

### DIFF
--- a/.github/workflows/agent-kit-release.yml
+++ b/.github/workflows/agent-kit-release.yml
@@ -3,10 +3,16 @@ name: Agent Kit Release
 # On a catalog release tag (e.g. agents-v1.0.0), run the full gate, build the
 # wire-shape catalog.json, sign it (HSM-backed, gated), verify the signature
 # against the pinned public key, and publish the artifacts to a GitHub Release.
+#
+# workflow_dispatch runs the same gate + sign + verify-against-pinned-key path on
+# demand (no tag, no GitHub Release). It exists so maintainers can exercise the
+# live Key Vault signing round-trip -- which executes nowhere else -- before
+# cutting a public release.
 on:
   push:
     tags:
       - "agents-v*"
+  workflow_dispatch:
 
 permissions:
   contents: write   # create the GitHub Release
@@ -30,6 +36,8 @@ jobs:
           fetch-depth: 0
 
       - name: Verify tagged commit is on main
+        # Only meaningful for a release tag; a dispatch dry-run publishes nothing.
+        if: ${{ github.event_name == 'push' }}
         run: |
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
           if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
@@ -95,7 +103,14 @@ jobs:
       - name: Stamp catalog_version
         run: |
           . .venv/bin/activate
-          endor-agent-kit stamp-catalog-version --catalog catalog.json --catalog-version "$CATALOG_TAG"
+          # On a tag push the stamp is the release tag; on a dispatch dry-run the
+          # output is never published, so any non-empty marker keeps the sign path running.
+          if [ "${{ github.event_name }}" = "push" ]; then
+            version="$CATALOG_TAG"
+          else
+            version="dry-run-$(git rev-parse --short HEAD)"
+          fi
+          endor-agent-kit stamp-catalog-version --catalog catalog.json --catalog-version "$version"
 
       # --- Signing (gated behind CATALOG_SIGNING_ENABLED; HSM-backed via Azure Key Vault over OIDC) ---
       - name: Azure login (OIDC)
@@ -125,12 +140,14 @@ jobs:
             --public-key keys/catalog-signing-public-key.pem
 
       - name: Refuse to publish an unsigned catalog
-        if: ${{ vars.CATALOG_SIGNING_ENABLED != 'true' }}
+        # Guards the release path only; a dispatch dry-run publishes nothing to refuse.
+        if: ${{ github.event_name == 'push' && vars.CATALOG_SIGNING_ENABLED != 'true' }}
         run: |
           echo "::error title=Signing required::CATALOG_SIGNING_ENABLED is not 'true'. Refusing to publish an unsigned catalog.json to a release -- consumers verify the signature. Enable Key Vault signing before tagging a release."
           exit 1
 
       - name: Publish GitHub Release
+        if: ${{ github.event_name == 'push' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
The Key Vault sign + verify path only runs during a real release (a tag push). That's the problem. Two signing bugs - a digest-encoding mismatch and a wrong `az keyvault key sign --query` field - only showed up against the live vault mid-release, because there's nowhere else the signing path executes. So we caught them the worst possible way: while cutting a release.

This adds a `workflow_dispatch` entry point so a maintainer can run the same sign + verify-against-pinned-key round-trip on demand - no tag, no GitHub Release - and catch that class of bug before it blocks a real release.

## What runs on each trigger

Same job, same `release` environment, so the OIDC subject and permissions match the real signing path exactly. The full gate (validate, test, regenerate, drift check, guardrails) runs on both. The difference is the tag-only steps, now gated on `github.event_name`:

1. `Verify tagged commit is on main` - `if: github.event_name == 'push'`. No tag on a dispatch, so nothing to verify.
2. `Stamp catalog_version` - on push it stamps `$CATALOG_TAG` as before; on dispatch it stamps `dry-run-<short-sha>` so the step doesn't choke on a missing tag and the sign path still runs. The dispatch output is never published, so the exact stamp value doesn't matter.
3. `Refuse to publish an unsigned catalog` - `if: github.event_name == 'push' && vars.CATALOG_SIGNING_ENABLED != 'true'`. It guards the release path; a dispatch publishes nothing to refuse.
4. `Publish GitHub Release` - `if: github.event_name == 'push'`. Never publishes on a dispatch.

The `CATALOG_SIGNING_ENABLED == 'true'` guard on the Azure login / sign / verify steps is unchanged, so those run on both paths when signing is enabled.

## Tracing both paths

- Tag push: every step behaves exactly as before - the tag-on-main check runs, stamp uses the tag, the unsigned guard fires if signing is off, the release publishes. No regression to the real release path.
- Dispatch: no tag required, sign + verify-against-pinned-key run, nothing is published.

## Validation

- YAML parses (`yaml.safe_load`), and both `push` and `workflow_dispatch` triggers are present.
- I can't hit the real vault from here, so the actual end-to-end AKV round-trip gets validated by *running* the dispatch after this merges (needs the `release` environment + Azure). This PR only wires up the entry point.

## One thing to be aware of

A dispatch runs the OIDC login + signing steps against whatever branch you point it at, and it skips the on-main ancestry check (that check only makes sense for a tag). So the `release` environment protection - required reviewers, allowed branches - is what gates who can reach the signing credentials this way. That's existing environment config, not touched here. Worth confirming it's set the way we want, but that's a separate change. Lmk if you'd rather I tighten the dispatch trigger itself instead.
