### PR TITLE
feat(catalog): emit codex install commands alongside claude-code

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -17,6 +17,10 @@
         {
           "host": "claude-code",
           "command": "/plugin marketplace add endorlabs/ai-plugins\n/plugin install endor-labs-agent-kit@endorlabs\n/reload-plugins"
+        },
+        {
+          "host": "codex",
+          "command": "codex plugin marketplace add endorlabs/ai-plugins --ref {{catalog_version}} --sparse .agents --sparse plugins/codex/endor-labs-agent-kit\ncodex plugin add endor-labs-agent-kit@endor-labs-agent-kit"
         }
       ],
       "legacy_ids": [
@@ -39,6 +43,10 @@
         {
           "host": "claude-code",
           "command": "/plugin marketplace add endorlabs/ai-plugins\n/plugin install endor-labs-agent-kit@endorlabs\n/reload-plugins"
+        },
+        {
+          "host": "codex",
+          "command": "codex plugin marketplace add endorlabs/ai-plugins --ref {{catalog_version}} --sparse .agents --sparse plugins/codex/endor-labs-agent-kit\ncodex plugin add endor-labs-agent-kit@endor-labs-agent-kit"
         }
       ]
     },
@@ -58,6 +66,10 @@
         {
           "host": "claude-code",
           "command": "/plugin marketplace add endorlabs/ai-plugins\n/plugin install endor-labs-agent-kit@endorlabs\n/reload-plugins"
+        },
+        {
+          "host": "codex",
+          "command": "codex plugin marketplace add endorlabs/ai-plugins --ref {{catalog_version}} --sparse .agents --sparse plugins/codex/endor-labs-agent-kit\ncodex plugin add endor-labs-agent-kit@endor-labs-agent-kit"
         }
       ],
       "legacy_ids": [
@@ -80,6 +92,10 @@
         {
           "host": "claude-code",
           "command": "/plugin marketplace add endorlabs/ai-plugins\n/plugin install endor-labs-agent-kit@endorlabs\n/reload-plugins"
+        },
+        {
+          "host": "codex",
+          "command": "codex plugin marketplace add endorlabs/ai-plugins --ref {{catalog_version}} --sparse .agents --sparse plugins/codex/endor-labs-agent-kit\ncodex plugin add endor-labs-agent-kit@endor-labs-agent-kit"
         }
       ],
       "legacy_ids": [
@@ -104,6 +120,10 @@
         {
           "host": "claude-code",
           "command": "/plugin marketplace add endorlabs/ai-plugins\n/plugin install endor-labs-agent-kit@endorlabs\n/reload-plugins"
+        },
+        {
+          "host": "codex",
+          "command": "codex plugin marketplace add endorlabs/ai-plugins --ref {{catalog_version}} --sparse .agents --sparse plugins/codex/endor-labs-agent-kit\ncodex plugin add endor-labs-agent-kit@endor-labs-agent-kit"
         }
       ]
     },
@@ -123,6 +143,10 @@
         {
           "host": "claude-code",
           "command": "/plugin marketplace add endorlabs/ai-plugins\n/plugin install endor-labs-agent-kit@endorlabs\n/reload-plugins"
+        },
+        {
+          "host": "codex",
+          "command": "codex plugin marketplace add endorlabs/ai-plugins --ref {{catalog_version}} --sparse .agents --sparse plugins/codex/endor-labs-agent-kit\ncodex plugin add endor-labs-agent-kit@endor-labs-agent-kit"
         }
       ],
       "legacy_ids": [
@@ -145,6 +169,10 @@
         {
           "host": "claude-code",
           "command": "/plugin marketplace add endorlabs/ai-plugins\n/plugin install endor-labs-agent-kit@endorlabs\n/reload-plugins"
+        },
+        {
+          "host": "codex",
+          "command": "codex plugin marketplace add endorlabs/ai-plugins --ref {{catalog_version}} --sparse .agents --sparse plugins/codex/endor-labs-agent-kit\ncodex plugin add endor-labs-agent-kit@endor-labs-agent-kit"
         }
       ],
       "legacy_ids": [
@@ -167,6 +195,10 @@
         {
           "host": "claude-code",
           "command": "/plugin marketplace add endorlabs/ai-plugins\n/plugin install endor-labs-agent-kit@endorlabs\n/reload-plugins"
+        },
+        {
+          "host": "codex",
+          "command": "codex plugin marketplace add endorlabs/ai-plugins --ref {{catalog_version}} --sparse .agents --sparse plugins/codex/endor-labs-agent-kit\ncodex plugin add endor-labs-agent-kit@endor-labs-agent-kit"
         }
       ],
       "legacy_ids": [
@@ -189,6 +221,10 @@
         {
           "host": "claude-code",
           "command": "/plugin marketplace add endorlabs/ai-plugins\n/plugin install endor-labs-agent-kit@endorlabs\n/reload-plugins"
+        },
+        {
+          "host": "codex",
+          "command": "codex plugin marketplace add endorlabs/ai-plugins --ref {{catalog_version}} --sparse .agents --sparse plugins/codex/endor-labs-agent-kit\ncodex plugin add endor-labs-agent-kit@endor-labs-agent-kit"
         }
       ]
     },
@@ -208,6 +244,10 @@
         {
           "host": "claude-code",
           "command": "/plugin marketplace add endorlabs/ai-plugins\n/plugin install endor-labs-agent-kit@endorlabs\n/reload-plugins"
+        },
+        {
+          "host": "codex",
+          "command": "codex plugin marketplace add endorlabs/ai-plugins --ref {{catalog_version}} --sparse .agents --sparse plugins/codex/endor-labs-agent-kit\ncodex plugin add endor-labs-agent-kit@endor-labs-agent-kit"
         }
       ],
       "legacy_ids": [
@@ -230,6 +270,10 @@
         {
           "host": "claude-code",
           "command": "/plugin marketplace add endorlabs/ai-plugins\n/plugin install endor-labs-agent-kit@endorlabs\n/reload-plugins"
+        },
+        {
+          "host": "codex",
+          "command": "codex plugin marketplace add endorlabs/ai-plugins --ref {{catalog_version}} --sparse .agents --sparse plugins/codex/endor-labs-agent-kit\ncodex plugin add endor-labs-agent-kit@endor-labs-agent-kit"
         }
       ]
     }

--- a/src/endor_agent_kit/publication/catalog_wire.py
+++ b/src/endor_agent_kit/publication/catalog_wire.py
@@ -31,12 +31,26 @@ AUDIENCES = frozenset({"appsec", "developer"})
 
 # repo host -> wire host name, in catalog install order. Claude Managed Agents
 # remain generated in the Agent Kit repository but are intentionally omitted
-# from the public catalog/UI. Cursor/Codex are proto-reserved and Gemini/
-# portable are not in the proto host enum.
+# from the public catalog/UI. Gemini/portable are generated but not published to
+# the catalog. Cursor ships as a monolithic plugin and is not compiled per agent,
+# so it has no manifest host records to project here yet.
 _WIRE_INSTALL_HOSTS: tuple[tuple[str, str], ...] = (
     ("claude-code", "claude-code"),
+    ("codex", "codex"),
 )
 _ENDORCTL_OPERATOR_RE = re.compile(r"^(?:>=|>)")
+
+# Sentinel the emitter writes where the release tag belongs; stamp_catalog_version
+# resolves it once the tag is known. The tag is not available at wire-build time
+# (the release pipeline stamps it in a later step), so hosts whose install command
+# pins a release ref emit this token instead.
+_CATALOG_VERSION_PLACEHOLDER = "{{catalog_version}}"
+
+# Codex install is a marketplace-add pinned to the release tag followed by the
+# plugin add; the package installs every workflow, so the command is agent
+# independent (same as claude-code).
+_CODEX_MARKETPLACE_NAME = "endor-labs-agent-kit"
+_CODEX_SPARSE_PLUGIN_PATH = "plugins/codex/endor-labs-agent-kit"
 
 
 def catalog_wire_payload(
@@ -83,7 +97,9 @@ def stamp_catalog_version(catalog_path: str | Path, catalog_version: str) -> Pat
     """Inject ``catalog_version`` (the release tag) into an existing catalog.json.
 
     The committed catalog.json carries no ``catalog_version`` (no tag exists at
-    commit time); the release pipeline stamps it just before signing.
+    commit time); the release pipeline stamps it just before signing. The same
+    tag resolves any install command that pinned it via
+    ``_CATALOG_VERSION_PLACEHOLDER`` (e.g. codex's ``--ref``).
     """
 
     path = Path(catalog_path)
@@ -95,8 +111,21 @@ def stamp_catalog_version(catalog_path: str | Path, catalog_version: str) -> Pat
     for key, value in payload.items():
         if key not in ("schema_version", "catalog_version"):
             stamped[key] = value
+    _resolve_install_version(stamped.get("agents", []), catalog_version)
     path.write_text(json.dumps(stamped, indent=2) + "\n", encoding="utf-8")
     return path
+
+
+def _resolve_install_version(agents: list[dict[str, Any]], catalog_version: str) -> None:
+    """Replace the release-tag placeholder in every install command in place."""
+
+    for agent in agents:
+        for entry in agent.get("install", []):
+            command = entry.get("command")
+            if isinstance(command, str) and _CATALOG_VERSION_PLACEHOLDER in command:
+                entry["command"] = command.replace(
+                    _CATALOG_VERSION_PLACEHOLDER, catalog_version
+                )
 
 
 def _endor_agent_record(group: list[CatalogAgent]) -> dict[str, Any] | None:
@@ -128,7 +157,7 @@ def _endor_agent_record(group: list[CatalogAgent]) -> dict[str, Any] | None:
         install.append({"host": wire_host, "command": _install_command(repo_host)})
     if not install:
         raise ValueError(
-            f"{representative.id}: no public install host (claude-code); cannot build install[]"
+            f"{representative.id}: no public install host (claude-code/codex); cannot build install[]"
         )
 
     record = {
@@ -172,12 +201,20 @@ def _validate_legacy_id_claims(by_id: dict[str, list[CatalogAgent]]) -> None:
 
 
 def _install_command(repo_host: str) -> str:
+    # Each command installs the whole package, so it is identical for every agent
+    # on that host.
     if repo_host == "claude-code":
-        # Same plugin install for every agent because the package installs all workflows.
         return (
             f"/plugin marketplace add {PUBLIC_CLAUDE_DISTRIBUTION_REPOSITORY}\n"
             f"/plugin install {PLUGIN_NAME}@{CLAUDE_MARKETPLACE_NAME}\n"
             "/reload-plugins"
+        )
+    if repo_host == "codex":
+        return (
+            f"codex plugin marketplace add {PUBLIC_CLAUDE_DISTRIBUTION_REPOSITORY} "
+            f"--ref {_CATALOG_VERSION_PLACEHOLDER} --sparse .agents "
+            f"--sparse {_CODEX_SPARSE_PLUGIN_PATH}\n"
+            f"codex plugin add {PLUGIN_NAME}@{_CODEX_MARKETPLACE_NAME}"
         )
     raise ValueError(f"unsupported install host {repo_host!r}")
 

--- a/tests/test_catalog_wire.py
+++ b/tests/test_catalog_wire.py
@@ -169,7 +169,7 @@ def test_cadence_is_omitted():
     assert "cadence" not in payload["agents"][0]
 
 
-def test_public_install_only_surfaces_claude_code():
+def test_public_install_excludes_non_wire_hosts():
     agents = [
         _agent("alpha-agent", "claude-code", "enterprise-edition"),
         _agent("alpha-agent", "claude-managed-agents", "enterprise-edition"),
@@ -309,3 +309,66 @@ def test_claude_managed_only_agent_is_not_publicly_installable():
 
     with pytest.raises(ValueError, match="no public install host"):
         catalog_wire_payload(agents)
+
+
+def _install_by_host(payload, host, agent_index=0):
+    install = payload["agents"][agent_index]["install"]
+    return next(entry["command"] for entry in install if entry["host"] == host)
+
+
+def test_agent_published_on_claude_code_and_codex_emits_both():
+    agents = [
+        _agent("alpha-agent", "claude-code", "enterprise-edition"),
+        _agent("alpha-agent", "codex", "enterprise-edition"),
+    ]
+    install = catalog_wire_payload(agents)["agents"][0]["install"]
+
+    # claude-code before codex, mirroring _WIRE_INSTALL_HOSTS order.
+    assert [entry["host"] for entry in install] == ["claude-code", "codex"]
+
+
+def test_codex_install_uses_distribution_marketplace_and_plugin_add():
+    payload = catalog_wire_payload([_agent("alpha-agent", "codex", "enterprise-edition")])
+    command = _install_by_host(payload, "codex")
+
+    assert command == (
+        "codex plugin marketplace add endorlabs/ai-plugins "
+        "--ref {{catalog_version}} --sparse .agents "
+        "--sparse plugins/codex/endor-labs-agent-kit\n"
+        "codex plugin add endor-labs-agent-kit@endor-labs-agent-kit"
+    )
+
+
+def test_codex_install_is_identical_across_agents():
+    payload = catalog_wire_payload(
+        [
+            _agent("alpha-agent", "codex", "enterprise-edition"),
+            _agent("zeta-agent", "codex", "enterprise-edition"),
+        ]
+    )
+    assert _install_by_host(payload, "codex", 0) == _install_by_host(payload, "codex", 1)
+
+
+def test_stamp_resolves_codex_ref_placeholder(tmp_path):
+    catalog = write_catalog(tmp_path, [_agent("alpha-agent", "codex", "enterprise-edition")])
+    assert "{{catalog_version}}" in json.loads(catalog.read_text(encoding="utf-8"))[
+        "agents"
+    ][0]["install"][0]["command"]
+
+    stamp_catalog_version(catalog, "agents-v1.1.0")
+
+    command = json.loads(catalog.read_text(encoding="utf-8"))["agents"][0]["install"][0][
+        "command"
+    ]
+    assert "{{catalog_version}}" not in command
+    assert "--ref agents-v1.1.0 " in command
+
+
+def test_stamp_leaves_placeholderless_commands_untouched(tmp_path):
+    catalog = write_catalog(tmp_path, [_agent("alpha-agent", "claude-code", "enterprise-edition")])
+    before = json.loads(catalog.read_text(encoding="utf-8"))["agents"][0]["install"][0]["command"]
+
+    stamp_catalog_version(catalog, "agents-v1.1.0")
+
+    after = json.loads(catalog.read_text(encoding="utf-8"))["agents"][0]["install"][0]["command"]
+    assert after == before


### PR DESCRIPTION
Adds `codex` to the published agent catalog so the Agents Hub can offer a Codex install path, not just Claude Code.

## Summary
- `catalog_wire.py`: add `codex` to the wire install hosts and author its install command (marketplace-add + `codex plugin add endor-labs-agent-kit@endor-labs-agent-kit`), taken verbatim from `docs/plugin-release-checklist.md`.
- `stamp_catalog_version`: resolve a `{{catalog_version}}` placeholder in install commands, so codex's `--ref` gets the real release tag at stamp time. The tag is not known when the wire payload is built, so the emitter writes the placeholder and the existing stamp step fills it.
- Regenerated `catalog.json` from the current manifest: all 11 agents now carry `claude-code` + `codex` install entries.

## Review notes
- This touches the release pipeline: `stamp_catalog_version` now also rewrites the `{{catalog_version}}` token inside install commands. No-op for commands without the token, so `claude-code` is unaffected. Flagging in case that seam matters to you.
- `cursor` and `antigravity` are intentionally out: cursor has no per-agent compiler/manifest records in this branch, and antigravity has no public install command documented. Only codex was ready to publish.

Related: AI-540 (monorepo host-enum companion).