### PR TITLE
Block ai-plugins publication when configured release evidence fails validation

### DIFF
--- a/.github/workflows/publish-ai-plugins-pr.yml
+++ b/.github/workflows/publish-ai-plugins-pr.yml
@@ -98,7 +98,7 @@ jobs:
         working-directory: endor-labs-agent-kit
         run: .venv/bin/python scripts/smoke_test_provider_installations.py --root .
 
-      - name: Report optional QA and backend release evidence
+      - name: Validate optional QA and backend release evidence
         if: ${{ env.DRY_RUN != 'true' }}
         working-directory: endor-labs-agent-kit
         env:
@@ -128,23 +128,26 @@ jobs:
           validation_status=$?
           set -e
 
+          printf '%s\n' "$validation_output"
+
           if [ "$validation_status" -ne 0 ]; then
-            echo "::warning title=Optional release evidence did not validate::QA/backend release evidence is advisory; publication will continue."
+            echo "::error title=Release evidence validation failed::Configured QA and backend release evidence does not validate against this commit. Publication is blocked."
             {
-              echo "## Optional release evidence"
+              echo "## Release evidence"
               echo
-              echo "Validation did not pass. Publication continues because release evidence is advisory."
+              echo "Validation failed, so this publication is blocked. Consumers accept the"
+              echo "mirrored catalog as one signed snapshot, so a single unsatisfied claim"
+              echo "invalidates the whole release."
               echo
               echo '```text'
               printf '%s\n' "$validation_output"
               echo '```'
             } >> "$GITHUB_STEP_SUMMARY"
-            exit 0
+            exit 1
           fi
 
-          printf '%s\n' "$validation_output"
           {
-            echo "## Optional release evidence"
+            echo "## Release evidence"
             echo
             echo "QA and backend release evidence validated successfully."
           } >> "$GITHUB_STEP_SUMMARY"
@@ -364,6 +367,7 @@ jobs:
           - \`endor-agent-kit publish ... --include-plugins\`
           - \`endor-agent-kit check-guardrails --catalog-root .\`
           - \`endor-agent-kit verify-provenance --catalog-root .\`
+          - \`scripts/validate_release_evidence.py\` whenever QA and backend release evidence are configured; missing evidence is reported and publication continues, invalid evidence blocks publication
           - Claude official root and self-contained Cursor marketplace boundary validation, conventional component checks, JSON checks, Cursor SDK compile check, Gemini no-zip check, and byte-for-byte generated-surface diffs
 
           ## Provenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,9 +58,9 @@ package metadata.
   evidence selects an upgrade candidate.
 - Routed generated Endor API commands through `endorctl agent api` with canonical
   agent identifiers so backend telemetry can attribute agent-originated calls.
-- Made exact-SHA QA and backend telemetry release evidence advisory in the
-  automated `ai-plugins` publication workflow while retaining strict manual
-  validation.
+- Made exact-SHA QA and backend telemetry release evidence optional to configure
+  in the automated `ai-plugins` publication workflow, while blocking publication
+  whenever configured evidence fails validation.
 - Added profile-aware execution bounds, compact evidence plans, and deterministic
   artifact summaries that avoid returning complete large inventories to the model.
 

--- a/docs/backend-agent-telemetry-acceptance.md
+++ b/docs/backend-agent-telemetry-acceptance.md
@@ -28,9 +28,12 @@ non-secret repository variables with the corresponding JSON objects:
 - `AGENT_QA_ACCEPTANCE_JSON`
 - `ENDOR_AGENT_BACKEND_ACCEPTANCE_JSON`
 
-When both variables are configured, the publication workflow validates them and
-reports the result. Missing, stale, mismatched-SHA, alias-incomplete, or
-correlation-incomplete evidence produces a warning and does not block
-publication. The standalone `scripts/validate_release_evidence.py` command
-remains strict and returns a nonzero status for invalid evidence. A manual
-`dry_run=true` may still regenerate and validate packages without publishing.
+Configuring the variables is optional. When neither is configured, the
+publication workflow records a warning and continues. When both are configured,
+the workflow validates them and stale, mismatched-SHA, alias-incomplete, or
+correlation-incomplete evidence fails the job and blocks publication: consumers
+accept the mirrored catalog as one signed snapshot, so a single unsatisfied
+claim invalidates the entire release. The standalone
+`scripts/validate_release_evidence.py` command returns the same nonzero status
+for invalid evidence. A manual `dry_run=true` may still regenerate and validate
+packages without publishing.

--- a/docs/plugin-release-checklist.md
+++ b/docs/plugin-release-checklist.md
@@ -146,9 +146,10 @@ For a real source-to-mirror publish, optionally provide both release evidence bu
 
 Validate the pair strictly with `scripts/validate_release_evidence.py` when the
 evidence is available; see `docs/backend-agent-telemetry-acceptance.md`. The
-automated publication workflow reports missing, stale, or invalid evidence as a
-warning and continues. A manual `dry_run=true` may regenerate and validate
-packages, but cannot publish.
+automated publication workflow reports unconfigured evidence as a warning and
+continues, but fails and blocks publication when configured evidence does not
+validate. A manual `dry_run=true` may regenerate and validate packages, but
+cannot publish.
 
 The final status check must show the Gemini extension directory and
 Antigravity package directory as tracked or untracked, not ignored. It must not

--- a/scripts/validate_release_evidence.py
+++ b/scripts/validate_release_evidence.py
@@ -75,11 +75,24 @@ def validate_release_evidence(
 
 
 def _load(path: Path | None, env_name: str | None, label: str) -> dict[str, object]:
-    raw = os.environ.get(env_name, "") if env_name else ""
+    # The environment variable and the file are mutually exclusive sources: an
+    # unset or blank variable must never silently fall back to reading a file.
+    invalid = ValueError(f"{label} is missing or invalid")
+    if env_name is not None:
+        raw = os.environ.get(env_name, "")
+    elif path is not None:
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise invalid from exc
+    else:
+        raise invalid
+    if not raw.strip():
+        raise invalid
     try:
-        value = json.loads(raw) if raw else json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise ValueError(f"{label} is missing or invalid") from exc
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise invalid from exc
     if not isinstance(value, dict):
         raise ValueError(f"{label} must be an object")
     return value

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1,6 +1,114 @@
 from __future__ import annotations
 
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
 from conftest import repo_root
+
+
+EVIDENCE_STEP_NAME = "Validate optional QA and backend release evidence"
+QA_VAR = "AGENT_QA_ACCEPTANCE_JSON"
+BACKEND_VAR = "ENDOR_AGENT_BACKEND_ACCEPTANCE_JSON"
+
+
+def publication_workflow_text() -> str:
+    return (
+        repo_root() / ".github" / "workflows" / "publish-ai-plugins-pr.yml"
+    ).read_text(encoding="utf-8")
+
+
+def evidence_step_script() -> str:
+    workflow = yaml.safe_load(publication_workflow_text())
+    steps = workflow["jobs"]["publish-ai-plugins-pr"]["steps"]
+    step = next(item for item in steps if item.get("name") == EVIDENCE_STEP_NAME)
+    return step["run"]
+
+
+def _stub_workspace(tmp_path: Path) -> Path:
+    """Mirror the workflow's working directory: a `.venv` python and the validator."""
+
+    workspace = tmp_path / "endor-labs-agent-kit"
+    (workspace / ".venv" / "bin").mkdir(parents=True)
+    (workspace / "scripts").mkdir(parents=True)
+    shim = workspace / ".venv" / "bin" / "python"
+    shim.write_text(f'#!/bin/sh\nexec "{sys.executable}" "$@"\n', encoding="utf-8")
+    shim.chmod(0o755)
+    shutil.copy(
+        repo_root() / "scripts" / "validate_release_evidence.py",
+        workspace / "scripts" / "validate_release_evidence.py",
+    )
+    shutil.copy(repo_root() / "catalog.json", workspace / "catalog.json")
+    return workspace
+
+
+def _release_evidence(source_commit: str) -> tuple[str, str]:
+    catalog = json.loads((repo_root() / "catalog.json").read_text(encoding="utf-8"))
+    qa = {
+        "status": "pass",
+        "publish_ready": True,
+        "coordinates": {"source_commits": {"treatment": source_commit}},
+    }
+    backend = {
+        "schema_version": "1",
+        "status": "pass",
+        "catalog_schema_version": 2,
+        "agent_api_transport": "endorctl agent api",
+        "canonical_agent_ids": [item["id"] for item in catalog["agents"]],
+        "legacy_aliases": {
+            alias: item["id"]
+            for item in catalog["agents"]
+            for alias in item.get("legacy_ids", [])
+        },
+        "audit_log_correlation": {
+            "status": "pass",
+            "observed_fields": [
+                "request_id",
+                "actor_type",
+                "canonical_agent_id",
+                "on_behalf_of",
+            ],
+            "canonical_agent_samples": len(catalog["agents"]),
+        },
+    }
+    return json.dumps(qa), json.dumps(backend)
+
+
+def _run_evidence_step(
+    tmp_path: Path, evidence: dict[str, str]
+) -> tuple[int, str, str]:
+    """Run the workflow step's script the way the Actions bash shell runs it."""
+
+    workspace = _stub_workspace(tmp_path)
+    script = tmp_path / "step.sh"
+    script.write_text(evidence_step_script(), encoding="utf-8")
+    summary = tmp_path / "step-summary.md"
+    summary.touch()
+    environment = {
+        "PATH": os.environ["PATH"],
+        "HOME": str(tmp_path),
+        "GITHUB_SHA": "a" * 40,
+        "GITHUB_STEP_SUMMARY": str(summary),
+        **evidence,
+    }
+    completed = subprocess.run(
+        ["bash", "--noprofile", "--norc", "-e", "-o", "pipefail", str(script)],
+        cwd=workspace,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return (
+        completed.returncode,
+        completed.stdout + completed.stderr,
+        summary.read_text(encoding="utf-8"),
+    )
 
 
 def test_ci_workflow_uses_source_agent_recipes():
@@ -69,23 +177,110 @@ def test_ai_plugins_publication_validates_codex_directory_and_pins_source_proven
     assert "build_codex_directory_submission.py validate --root ." in workflow
 
 
-def test_ai_plugins_publication_reports_release_evidence_without_gating() -> None:
-    workflow = (
-        repo_root() / ".github" / "workflows" / "publish-ai-plugins-pr.yml"
-    ).read_text()
-    evidence_step = workflow.split(
-        "- name: Report optional QA and backend release evidence", 1
-    )[1].split("- name: Regenerate catalog", 1)[0]
+def test_ai_plugins_publication_gates_on_invalid_release_evidence_only() -> None:
+    workflow = publication_workflow_text()
+    evidence_step = workflow.split(f"- name: {EVIDENCE_STEP_NAME}", 1)[1].split(
+        "- name: Regenerate catalog", 1
+    )[0]
+    unconfigured_branch, failure_branch = evidence_step.split(
+        'if [ "$validation_status" -ne 0 ]', 1
+    )
 
-    assert "Report optional QA and backend release evidence" in workflow
-    assert "Require QA and backend release evidence" not in workflow
-    assert "Optional release evidence unavailable" in evidence_step
-    assert "Optional release evidence did not validate" in evidence_step
-    assert "Publication will continue" in evidence_step
     assert "scripts/validate_release_evidence.py" in evidence_step
-    assert evidence_step.count("exit 0") == 2
-    assert "exit 1" not in evidence_step
     assert "continue-on-error" not in evidence_step
+
+    # Unconfigured evidence stays advisory.
+    assert "Optional release evidence unavailable" in unconfigured_branch
+    assert "Publication will continue" in unconfigured_branch
+    assert unconfigured_branch.count("exit 0") == 1
+
+    # Configured evidence that fails validation must fail the job, and must not
+    # describe itself as advisory or continuing.
+    assert "exit 1" in failure_branch
+    assert "::error title=Release evidence validation failed" in failure_branch
+    assert "exit 0" not in failure_branch
+    assert "advisory" not in failure_branch.lower()
+    assert "will continue" not in failure_branch.lower()
+
+
+def test_ai_plugins_publication_pr_body_describes_release_evidence_gate() -> None:
+    workflow = publication_workflow_text()
+    pr_body = workflow.split("- name: Write ai-plugins PR body", 1)[1].split(
+        "- name: Report dry-run diff", 1
+    )[0]
+
+    assert "validate_release_evidence.py" in pr_body
+    assert "invalid evidence blocks publication" in pr_body
+    assert "advisory" not in pr_body.lower()
+
+
+def test_release_evidence_step_warns_and_continues_when_unconfigured(tmp_path) -> None:
+    status, output, summary = _run_evidence_step(tmp_path, {})
+
+    assert status == 0
+    assert "::warning title=Optional release evidence unavailable" in output
+    assert QA_VAR in output
+    assert BACKEND_VAR in output
+    assert "Publication will continue." in summary
+
+
+def test_release_evidence_step_continues_when_only_one_variable_is_set(
+    tmp_path,
+) -> None:
+    qa, _ = _release_evidence("a" * 40)
+
+    status, output, summary = _run_evidence_step(tmp_path, {QA_VAR: qa})
+
+    assert status == 0
+    assert "::warning title=Optional release evidence unavailable" in output
+    assert BACKEND_VAR in summary
+    assert QA_VAR not in summary
+
+
+def test_release_evidence_step_fails_when_configured_evidence_is_invalid(
+    tmp_path,
+) -> None:
+    qa, backend_json = _release_evidence("a" * 40)
+    backend = json.loads(backend_json)
+    backend["catalog_schema_version"] = 1
+
+    status, output, summary = _run_evidence_step(
+        tmp_path, {QA_VAR: qa, BACKEND_VAR: json.dumps(backend)}
+    )
+
+    assert status != 0
+    assert "::error title=Release evidence validation failed" in output
+    assert "backend must accept catalog schema version 2" in output
+    assert "backend must accept catalog schema version 2" in summary
+    assert "blocked" in summary
+    assert "Traceback" not in output
+
+
+def test_release_evidence_step_fails_when_configured_evidence_is_unparseable(
+    tmp_path,
+) -> None:
+    qa, backend = _release_evidence("a" * 40)
+
+    status, output, _ = _run_evidence_step(
+        tmp_path, {QA_VAR: "not json", BACKEND_VAR: backend}
+    )
+
+    assert status != 0
+    assert "ERROR: QA acceptance is missing or invalid" in output
+    assert "Traceback" not in output
+
+
+def test_release_evidence_step_passes_with_valid_evidence(tmp_path) -> None:
+    qa, backend = _release_evidence("a" * 40)
+
+    status, output, summary = _run_evidence_step(
+        tmp_path, {QA_VAR: qa, BACKEND_VAR: backend}
+    )
+
+    assert status == 0
+    assert "OK: QA and backend release evidence" in output
+    assert "validated successfully" in summary
+    assert "blocked" not in summary
 
 
 def test_codex_directory_submission_workflow_requires_immutable_mirror_sha():

--- a/tests/test_release_evidence.py
+++ b/tests/test_release_evidence.py
@@ -1,10 +1,67 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
-from scripts.validate_release_evidence import validate_release_evidence
+import pytest
+
+from scripts.validate_release_evidence import _load, main, validate_release_evidence
 
 from conftest import repo_root
+
+
+SOURCE_COMMIT = "a" * 40
+
+
+def _catalog() -> dict[str, object]:
+    return json.loads((repo_root() / "catalog.json").read_text(encoding="utf-8"))
+
+
+def _cli_argv(*extra: str) -> list[str]:
+    return [
+        "validate_release_evidence.py",
+        "--source-commit",
+        SOURCE_COMMIT,
+        "--catalog",
+        str(repo_root() / "catalog.json"),
+        "--qa-acceptance-env",
+        "AGENT_QA_ACCEPTANCE_JSON",
+        "--backend-acceptance-env",
+        "ENDOR_AGENT_BACKEND_ACCEPTANCE_JSON",
+        *extra,
+    ]
+
+
+def _valid_evidence(catalog: dict[str, object]) -> tuple[dict, dict]:
+    agents = catalog["agents"]
+    qa = {
+        "status": "pass",
+        "publish_ready": True,
+        "coordinates": {"source_commits": {"treatment": SOURCE_COMMIT}},
+    }
+    backend = {
+        "schema_version": "1",
+        "status": "pass",
+        "catalog_schema_version": 2,
+        "agent_api_transport": "endorctl agent api",
+        "canonical_agent_ids": [item["id"] for item in agents],
+        "legacy_aliases": {
+            alias: item["id"]
+            for item in agents
+            for alias in item.get("legacy_ids", [])
+        },
+        "audit_log_correlation": {
+            "status": "pass",
+            "observed_fields": [
+                "request_id",
+                "actor_type",
+                "canonical_agent_id",
+                "on_behalf_of",
+            ],
+            "canonical_agent_samples": len(agents),
+        },
+    }
+    return qa, backend
 
 
 def test_release_evidence_binds_qa_backend_aliases_and_audit_log_to_catalog() -> None:
@@ -72,3 +129,206 @@ def test_release_evidence_requires_exact_full_source_commit() -> None:
     )
 
     assert "QA treatment and publishing source commits must be full immutable Git SHAs" in errors
+
+
+def test_load_reports_missing_evidence_when_environment_variable_is_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AGENT_QA_ACCEPTANCE_JSON", raising=False)
+
+    # An unset variable must not fall through to a file read; that raised an
+    # AttributeError instead of the actionable validation error.
+    with pytest.raises(ValueError, match="QA acceptance is missing or invalid"):
+        _load(None, "AGENT_QA_ACCEPTANCE_JSON", "QA acceptance")
+
+
+@pytest.mark.parametrize("raw", ["", "   \n", "not json", "{"])
+def test_load_reports_missing_evidence_for_blank_or_unparseable_variables(
+    monkeypatch: pytest.MonkeyPatch, raw: str
+) -> None:
+    monkeypatch.setenv("BACKEND_EVIDENCE", raw)
+
+    with pytest.raises(ValueError, match="backend acceptance is missing or invalid"):
+        _load(None, "BACKEND_EVIDENCE", "backend acceptance")
+
+
+def test_load_rejects_non_object_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BACKEND_EVIDENCE", "[1, 2]")
+
+    with pytest.raises(ValueError, match="backend acceptance must be an object"):
+        _load(None, "BACKEND_EVIDENCE", "backend acceptance")
+
+
+def test_load_ignores_a_populated_file_when_an_environment_variable_is_selected(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    path = tmp_path / "evidence.json"
+    path.write_text(json.dumps({"from": "file"}), encoding="utf-8")
+    monkeypatch.setenv("QA_EVIDENCE", json.dumps({"from": "env"}))
+
+    assert _load(path, "QA_EVIDENCE", "QA acceptance") == {"from": "env"}
+
+
+def test_load_reads_a_file_when_no_environment_variable_is_selected(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "evidence.json"
+    path.write_text(json.dumps({"from": "file"}), encoding="utf-8")
+
+    assert _load(path, None, "catalog") == {"from": "file"}
+
+
+def test_load_reports_missing_evidence_for_unreadable_or_absent_sources(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ValueError, match="catalog is missing or invalid"):
+        _load(tmp_path / "absent.json", None, "catalog")
+
+    with pytest.raises(ValueError, match="catalog is missing or invalid"):
+        _load(None, None, "catalog")
+
+
+def test_cli_reports_unset_evidence_variable_without_a_traceback(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.delenv("AGENT_QA_ACCEPTANCE_JSON", raising=False)
+    monkeypatch.delenv("ENDOR_AGENT_BACKEND_ACCEPTANCE_JSON", raising=False)
+    monkeypatch.setattr("sys.argv", _cli_argv())
+
+    assert main() == 1
+    captured = capsys.readouterr()
+    assert "ERROR: QA acceptance is missing or invalid" in captured.out
+    assert "Traceback" not in captured.out + captured.err
+
+
+def test_cli_passes_and_fails_on_configured_evidence(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    catalog = _catalog()
+    qa, backend = _valid_evidence(catalog)
+    monkeypatch.setenv("AGENT_QA_ACCEPTANCE_JSON", json.dumps(qa))
+    monkeypatch.setenv("ENDOR_AGENT_BACKEND_ACCEPTANCE_JSON", json.dumps(backend))
+    monkeypatch.setattr("sys.argv", _cli_argv())
+
+    assert main() == 0
+    assert "OK: QA and backend release evidence" in capsys.readouterr().out
+
+    backend["catalog_schema_version"] = 1
+    monkeypatch.setenv("ENDOR_AGENT_BACKEND_ACCEPTANCE_JSON", json.dumps(backend))
+
+    assert main() == 1
+    assert "ERROR: backend must accept catalog schema version 2" in capsys.readouterr().out
+
+
+def test_cli_requires_exactly_one_evidence_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("sys.argv", _cli_argv("--qa-acceptance", "benchmark.json"))
+
+    with pytest.raises(SystemExit) as raised:
+        main()
+
+    assert raised.value.code == 2
+
+
+def test_release_evidence_rejects_a_catalog_without_agent_objects() -> None:
+    qa, backend = _valid_evidence(_catalog())
+
+    assert validate_release_evidence(
+        source_commit=SOURCE_COMMIT,
+        qa=qa,
+        backend=backend,
+        catalog={"agents": ["dependency-reviewer"]},
+    ) == ["catalog agents must be an array of objects"]
+
+
+def test_release_evidence_requires_the_full_canonical_agent_set() -> None:
+    catalog = _catalog()
+    qa, backend = _valid_evidence(catalog)
+    trimmed = {"agents": catalog["agents"][:-1]}
+
+    errors = validate_release_evidence(
+        source_commit=SOURCE_COMMIT,
+        qa=qa,
+        backend=backend,
+        catalog=trimmed,
+    )
+
+    assert "catalog must contain exactly 11 canonical agents" in errors
+    assert "backend canonical agent ids must exactly match catalog ids" in errors
+
+
+@pytest.mark.parametrize(
+    ("mutate", "expected"),
+    [
+        (
+            lambda qa, backend: qa.update(status="fail"),
+            "QA benchmark acceptance must pass",
+        ),
+        (
+            lambda qa, backend: qa.update(publish_ready=False),
+            "QA benchmark acceptance must pass",
+        ),
+        (
+            lambda qa, backend: qa.pop("coordinates"),
+            "QA treatment and publishing source commits must be full immutable Git SHAs",
+        ),
+        (
+            lambda qa, backend: qa.update(
+                coordinates={"source_commits": {"treatment": "b" * 40}}
+            ),
+            "QA treatment commit must match the publishing source commit",
+        ),
+        (
+            lambda qa, backend: backend.update(schema_version="2"),
+            "backend acceptance must use schema_version 1",
+        ),
+        (
+            lambda qa, backend: backend.update(status="fail"),
+            "backend acceptance must pass",
+        ),
+        (
+            lambda qa, backend: backend.update(catalog_schema_version=1),
+            "backend must accept catalog schema version 2",
+        ),
+        (
+            lambda qa, backend: backend.update(agent_api_transport="endorctl api"),
+            "backend evidence must cover endorctl agent api",
+        ),
+        (
+            lambda qa, backend: backend.update(canonical_agent_ids=["unknown"]),
+            "backend canonical agent ids must exactly match catalog ids",
+        ),
+        (
+            lambda qa, backend: backend.update(
+                audit_log_correlation={"status": "fail"}
+            ),
+            "backend audit-log correlation must pass",
+        ),
+        (
+            lambda qa, backend: backend["audit_log_correlation"].update(
+                observed_fields=["request_id"]
+            ),
+            "backend audit-log correlation is missing required fields",
+        ),
+        (
+            lambda qa, backend: backend["audit_log_correlation"].update(
+                canonical_agent_samples=1
+            ),
+            "backend audit-log evidence must sample every canonical agent",
+        ),
+    ],
+)
+def test_release_evidence_reports_every_unsatisfied_claim(mutate, expected: str) -> None:
+    catalog = _catalog()
+    qa, backend = _valid_evidence(catalog)
+    mutate(qa, backend)
+
+    errors = validate_release_evidence(
+        source_commit=SOURCE_COMMIT,
+        qa=qa,
+        backend=backend,
+        catalog=catalog,
+    )
+
+    assert expected in errors


### PR DESCRIPTION
## Problem

The publication workflow's release-evidence step warned and continued in two very
different situations: when the evidence repository variables were not configured
at all, and when the configured evidence ran through
`scripts/validate_release_evidence.py` and failed. The second case is a real
release defect being waved through.

A non-zero validator exit means one of: the backend does not accept catalog
`schema_version: v2`, the legacy-alias map does not match the catalog, or the QA
treatment SHA is not the SHA being published. The downstream consumer accepts
`catalog.json` as an all-or-nothing signed snapshot, so any one of those
unsatisfied claims makes it reject the entire release. Publishing anyway only
moves the failure downstream, after the mirror PR already exists.

## Change

- Unconfigured evidence stays advisory: same `::warning`, same step-summary note,
  step still exits 0. Configuring the variables remains optional.
- Configured evidence that fails validation now surfaces the validator output,
  writes a step summary explaining the block, and fails the job. The failure path
  no longer calls itself advisory or claims publication will continue.
- Renamed the step to `Validate optional QA and backend release evidence`, since
  it now gates rather than only reports, and added a matching bullet to the
  generated mirror PR body.
- Fixed a latent crash in `_load()`. With `--qa-acceptance-env FOO` and `FOO`
  unset or blank, the old code fell through to `path.read_text()` even though
  `main()` guarantees the path is `None` in that branch, producing an
  `AttributeError` traceback instead of `ERROR: QA acceptance is missing or
  invalid` (the `except` clause caught only `OSError` and `JSONDecodeError`). The
  environment and file sources are now mutually exclusive, and an unset, blank,
  or unparseable source raises the intended `ValueError`. This matters more now
  that a non-zero exit fails the build.
- Updated the docs and changelog wording that described invalid evidence as
  non-blocking.

## Tests

`tests/test_ci_workflow.py` now extracts the step's script straight out of the
workflow YAML and runs it under the same bash flags Actions uses, against the
real validator, covering all three paths: unconfigured (warns, exits 0), only one
variable set (warns, exits 0), invalid evidence (fails, no traceback, validator
error text in the job summary), unparseable evidence (fails), and valid evidence
(passes).

The previous assertions that pinned the advisory-on-failure behavior (`exit 0`
twice, no `exit 1`) are inverted rather than dropped, and the advisory assertions
are now scoped to the unconfigured branch so they cannot leak back into the
failure branch.

`tests/test_release_evidence.py` adds direct `_load()` coverage for the unset,
blank, unparseable, non-object, file, and no-source cases, CLI-level coverage
asserting the clean error instead of a traceback, and per-claim coverage of every
validator error message.

All three CI test lanes pass, plus `scripts/check_repository_hygiene.py`.
